### PR TITLE
JaCoCo 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.0.4'
     id 'io.spring.dependency-management' version '1.1.0'
     id 'checkstyle'
+    id 'jacoco'
 }
 
 group = 'com.flab'
@@ -20,6 +21,7 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 compileJava.options.encoding = 'UTF-8'
@@ -35,4 +37,18 @@ tasks.withType(Checkstyle) {
 checkstyle {
     configFile = file("checkstyle/naver-checkstyle-rules.xml")
     configProperties = ["suppressionFile": "checkstyle/naver-checkstyle-suppressions.xml"]
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+jacocoTestReport {
+    executionData(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
+
+    reports {
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+    }
 }


### PR DESCRIPTION
jacocoTestReports Task 설정까지 완료된 상태입니다.
- 생성된 리포트 파일로 커버리지를 확인할 수 있습니다.
- jacocoTestCoverageVerification Task는 추후에 커버리지에 대한 명확한 기준을 설정하고 싶을 경우 적용하기 위해서 추가하지 않았습니다.

This closes #6 