### PR TITLE
회원가입 기능 리팩토링

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -22,8 +22,6 @@ include::{snippets}/member-join/response-fields.adoc[]
 **http_request**
 include::{snippets}/member-join/request-body.adoc[]
 
-NOTE: tid 필드는 회원가입 후 등록된 tid를 반환받기 위한 필드로 회원 가입 요청 시에는 포함하지 않습니다.
-
 **http_response**
 include::{snippets}/member-join/http-response.adoc[]
 

--- a/src/main/java/com/flab/comen/member/domain/Member.java
+++ b/src/main/java/com/flab/comen/member/domain/Member.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Member extends BaseTime {
 
-	private Long tid;
 	private String email;
 	private String password;
 	private String name;

--- a/src/main/java/com/flab/comen/member/dto/JoinRequest.java
+++ b/src/main/java/com/flab/comen/member/dto/JoinRequest.java
@@ -15,9 +15,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JoinRequest {
 
-	// 회원가입 쿼리에서 tid를 반환하기 위한 필드
-	private Long tid;
-
 	@NotBlank(message = "이메일 주소를 입력해 주세요.")
 	@Email(message = "이메일 형식이 맞지 않습니다.")
 	String email;

--- a/src/main/java/com/flab/comen/member/mapper/MemberMapper.java
+++ b/src/main/java/com/flab/comen/member/mapper/MemberMapper.java
@@ -11,7 +11,5 @@ import com.flab.comen.member.dto.JoinRequest;
 public interface MemberMapper {
 	Optional<Member> findByEmail(String email);
 
-	Optional<Member> findByTid(Long tid);
-
 	void join(JoinRequest dto);
 }

--- a/src/main/java/com/flab/comen/member/service/MemberService.java
+++ b/src/main/java/com/flab/comen/member/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
 
 		memberMapper.join(joinRequest);
 
-		Member savedMember = getByTid(joinRequest.getTid());
+		Member savedMember = getByEmail(joinRequest.getEmail());
 
 		return JoinResponse.builder()
 			.email(savedMember.getEmail())
@@ -43,8 +43,8 @@ public class MemberService {
 			.activeType(savedMember.getActiveType()).build();
 	}
 
-	public Member getByTid(Long tid) {
-		return memberMapper.findByTid(tid).orElseThrow(() -> {
+	public Member getByEmail(String email) {
+		return memberMapper.findByEmail(email).orElseThrow(() -> {
 			throw new MemberNotFoundException(MEMBER_NOT_FOUND.getMessage());
 		});
 	}

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -7,21 +7,23 @@
 
     <insert id="join" parameterType="com.flab.comen.member.dto.JoinRequest">
         INSERT INTO member(
-        email,
-        password,
-        name,
-        role,
-        created_dt,
-        updated_dt)
+                            email,
+                            password,
+                            name,
+                            role,
+                            created_dt,
+                            updated_dt)
         VALUES (
-        #{email},
-        #{password},
-        #{name},
-        #{role},
-        NOW(),
-        NOW())
-        <selectKey keyProperty="tid" resultType="Long" order="AFTER">
-            SELECT LAST_INSERT_ID()
+                #{email},
+                #{password},
+                #{name},
+                #{role},
+                NOW(),
+                NOW())
+        <selectKey keyProperty="email" resultType="String" order="AFTER">
+            SELECT email
+            FROM member
+            WHERE email = #{email}
         </selectKey>
     </insert>
 
@@ -29,12 +31,6 @@
         SELECT *
         FROM member
         WHERE email = #{email}
-    </select>
-
-    <select id="findByTid" parameterType="Long" resultType="com.flab.comen.member.domain.Member">
-        SELECT *
-        FROM member
-        WHERE tid = #{tid}
     </select>
 
 </mapper>

--- a/src/test/java/com/flab/comen/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/flab/comen/member/controller/MemberControllerTest.java
@@ -93,8 +93,7 @@ class MemberControllerTest {
 						fieldWithPath("password").type(JsonFieldType.STRING)
 								.description("비밀번호(8자~16자 이하의 영문 대소문자/숫자/특수문자 조합)"),
 						fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
-						fieldWithPath("role").type(JsonFieldType.STRING).description("에프랩 내에서의 역할(COACH|MENTEE)"),
-						fieldWithPath("tid").ignored()
+						fieldWithPath("role").type(JsonFieldType.STRING).description("에프랩 내에서의 역할(COACH|MENTEE)")
 					),
 					responseFields(
 						fieldWithPath("email").type(JsonFieldType.STRING).description("가입된 이메일 정보"),

--- a/src/test/java/com/flab/comen/member/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/comen/member/service/MemberServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.flab.comen.member.domain.Member;
 import com.flab.comen.member.dto.JoinRequest;
+import com.flab.comen.member.exception.MemberNotFoundException;
 import com.flab.comen.member.mapper.MemberMapper;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,14 +47,14 @@ class MemberServiceTest {
 		}
 
 		@Test
-		@DisplayName("등록된 회원 정보가 없다면 NoSuchElementException이 발생한다.")
+		@DisplayName("등록된 회원 정보가 없다면 MemberNotFoundException이 발생한다.")
 		void when_memberDoesNotExist_expect_throwsNoSuchElementException() {
-			Long newTid = 2L;
+			String email = "comen@comen.com";
 
-			given(memberMapper.findByTid(anyLong())).willThrow(NoSuchElementException.class);
+			given(memberMapper.findByEmail(anyString())).willThrow(MemberNotFoundException.class);
 
-			assertThrows(NoSuchElementException.class, () -> {
-				memberService.getByTid(newTid);
+			assertThrows(MemberNotFoundException.class, () -> {
+				memberService.getByEmail(email);
 			});
 		}
 	}


### PR DESCRIPTION
## 내용
member 테이블의 tid 컬럼 삭제에 따른 기존 로직을 변경했습니다.

<br>

## 참고
기존에 tid를 반환하던 selectKey 구문을 email로 변경했습니다.
```
<selectKey keyProperty="email" resultType="String" order="AFTER">
            SELECT email
            FROM member
            WHERE email = #{email}
</selectKey>
```

<br>

### 개선점
- 기존 JoinRequest에 반환값 때문에 null값으로 존재했던 tid 필드를 제거했습니다.
- API 명세에서 HTTP request에서 필요한 필드만 확인할 수 있습니다.

<br>

**변경 전**
<img width="798" alt="스크린샷 2023-04-05 오전 12 12 15" src="https://user-images.githubusercontent.com/80027033/229837582-eef7d7ac-94b6-4a99-a51e-4203dc32238c.png">

**변경 후**
<img width="987" alt="스크린샷 2023-04-05 오전 12 11 14" src="https://user-images.githubusercontent.com/80027033/229837291-cc3ad9aa-7844-4f60-959c-70809c807835.png">
