### PR TITLE
Exception handling 리팩토링

### DIFF
--- a/src/main/java/com/flab/comen/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/flab/comen/global/exception/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.flab.comen.global.exception;
 
+import static com.flab.comen.global.exception.ErrorMessage.*;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -9,7 +11,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import com.flab.comen.member.exception.MemberNotFoundException;
+import com.flab.comen.member.exception.DuplicatedEmailException;
+import com.flab.comen.member.exception.NotExistedMemberException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,27 +22,24 @@ public class ApiExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException exception) {
-		Map<String, String> errors = new HashMap<>();
+		log.error("MethodArgumentNotValidException : ", exception);
 
+		Map<String, String> errors = new HashMap<>();
 		exception.getBindingResult().getAllErrors()
 			.forEach(e -> errors.put(((FieldError)e).getField(), e.getDefaultMessage()));
-
-		log.error("MethodArgumentNotValidException : ", exception);
 
 		return ResponseEntity.badRequest().body(errors);
 	}
 
-	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
-		log.error("IllegalArgumentException : ", exception);
-
-		return ResponseEntity.badRequest().body(exception.getMessage());
+	@ExceptionHandler(DuplicatedEmailException.class)
+	private ResponseEntity<ErrorResponse> handleDuplicatedEmailException(DuplicatedEmailException exception) {
+		log.error("DuplicatedEmailException : ", exception);
+		return ErrorResponse.toResponseEntity(DUPLICATED_EMAIL);
 	}
 
-	@ExceptionHandler(MemberNotFoundException.class)
-	public ResponseEntity<String> handleMemberNotFoundException(MemberNotFoundException exception) {
-		log.error("MemberNotFoundException : ", exception);
-
-		return ResponseEntity.badRequest().body(exception.getMessage());
+	@ExceptionHandler(NotExistedMemberException.class)
+	private ResponseEntity<ErrorResponse> handleNotExistedMemberException(NotExistedMemberException exception) {
+		log.error("NotExistedMemberException : ", exception);
+		return ErrorResponse.toResponseEntity(NOT_EXISTED_MEMBER);
 	}
 }

--- a/src/main/java/com/flab/comen/global/exception/ErrorMessage.java
+++ b/src/main/java/com/flab/comen/global/exception/ErrorMessage.java
@@ -1,17 +1,22 @@
 package com.flab.comen.global.exception;
 
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
 public enum ErrorMessage {
 
-	DUPLICATED_EMAIL("이미 등록된 이메일 주소입니다."),
-	MEMBER_NOT_FOUND("등록된 회원 정보가 없습니니다.");
+	DUPLICATED_EMAIL(409, HttpStatus.CONFLICT, "이미 등록된 이메일 주소입니다."),
+	NOT_EXISTED_MEMBER(404, HttpStatus.NOT_FOUND, "등록된 회원 정보가 없습니니다.");
 
-	private final String message;
+	private int status;
+	private HttpStatus error;
+	private String message;
 
-	ErrorMessage(String message) {
+	ErrorMessage(int status, HttpStatus error, String message) {
+		this.status = status;
+		this.error = error;
 		this.message = message;
-	}
-
-	public String getMessage() {
-		return message;
 	}
 }

--- a/src/main/java/com/flab/comen/global/exception/ErrorResponse.java
+++ b/src/main/java/com/flab/comen/global/exception/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.flab.comen.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+	private final int status;
+	private final HttpStatus error;
+	private final String message;
+
+	public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorMessage errorMessage) {
+		return ResponseEntity
+			.status(errorMessage.getStatus())
+			.body(ErrorResponse.builder()
+				.status(errorMessage.getStatus())
+				.error(errorMessage.getError())
+				.message(errorMessage.getMessage())
+				.build()
+			);
+	}
+}

--- a/src/main/java/com/flab/comen/member/exception/DuplicatedEmailException.java
+++ b/src/main/java/com/flab/comen/member/exception/DuplicatedEmailException.java
@@ -1,0 +1,4 @@
+package com.flab.comen.member.exception;
+
+public class DuplicatedEmailException extends RuntimeException {
+}

--- a/src/main/java/com/flab/comen/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/flab/comen/member/exception/MemberNotFoundException.java
@@ -1,7 +1,0 @@
-package com.flab.comen.member.exception;
-
-public class MemberNotFoundException extends RuntimeException {
-	public MemberNotFoundException(String message) {
-		super(message);
-	}
-}

--- a/src/main/java/com/flab/comen/member/exception/NotExistedMemberException.java
+++ b/src/main/java/com/flab/comen/member/exception/NotExistedMemberException.java
@@ -1,0 +1,4 @@
+package com.flab.comen.member.exception;
+
+public class NotExistedMemberException extends RuntimeException {
+}

--- a/src/main/java/com/flab/comen/member/service/MemberService.java
+++ b/src/main/java/com/flab/comen/member/service/MemberService.java
@@ -1,14 +1,13 @@
 package com.flab.comen.member.service;
 
-import static com.flab.comen.global.exception.ErrorMessage.*;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.flab.comen.member.domain.Member;
 import com.flab.comen.member.dto.JoinRequest;
 import com.flab.comen.member.dto.JoinResponse;
-import com.flab.comen.member.exception.MemberNotFoundException;
+import com.flab.comen.member.exception.DuplicatedEmailException;
+import com.flab.comen.member.exception.NotExistedMemberException;
 import com.flab.comen.member.mapper.MemberMapper;
 
 @Service
@@ -26,7 +25,7 @@ public class MemberService {
 	public JoinResponse join(JoinRequest joinRequest) {
 
 		memberMapper.findByEmail(joinRequest.getEmail()).ifPresent(it -> {
-			throw new IllegalArgumentException(DUPLICATED_EMAIL.getMessage());
+			throw new DuplicatedEmailException();
 		});
 
 		String encryptPassword = passwordEncoder.encode(joinRequest.getPassword());
@@ -45,7 +44,7 @@ public class MemberService {
 
 	public Member getByEmail(String email) {
 		return memberMapper.findByEmail(email).orElseThrow(() -> {
-			throw new MemberNotFoundException(MEMBER_NOT_FOUND.getMessage());
+			throw new NotExistedMemberException();
 		});
 	}
 }

--- a/src/test/java/com/flab/comen/member/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/comen/member/service/MemberServiceTest.java
@@ -5,7 +5,6 @@ import static com.flab.comen.member.domain.Role.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.flab.comen.member.domain.Member;
 import com.flab.comen.member.dto.JoinRequest;
-import com.flab.comen.member.exception.MemberNotFoundException;
+import com.flab.comen.member.exception.DuplicatedEmailException;
+import com.flab.comen.member.exception.NotExistedMemberException;
 import com.flab.comen.member.mapper.MemberMapper;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,26 +34,26 @@ class MemberServiceTest {
 	@DisplayName("회원가입")
 	class JoinTest {
 		@Test
-		@DisplayName("email이 중복되었다면 IllegalArgumentException이 발생한다.")
-		void when_emailIsDuplicated_expect_throwsIllegalArgumentException() {
+		@DisplayName("email이 중복되었다면 DuplicatedEmailException이 발생한다.")
+		void when_emailIsDuplicated_expect_throwsDuplicatedEmailException() {
 			Member member = Member.of("email", "password", "name", MENTEE, ACTIVE);
 			JoinRequest joinRequest = new JoinRequest("email", "password", "name", MENTEE);
 
 			given(memberMapper.findByEmail(anyString())).willReturn(Optional.of(member));
 
-			assertThrows(IllegalArgumentException.class, () -> {
+			assertThrows(DuplicatedEmailException.class, () -> {
 				memberService.join(joinRequest);
 			});
 		}
 
 		@Test
-		@DisplayName("등록된 회원 정보가 없다면 MemberNotFoundException이 발생한다.")
-		void when_memberDoesNotExist_expect_throwsNoSuchElementException() {
+		@DisplayName("등록된 회원 정보가 없다면 NotExistedMemberException이 발생한다.")
+		void when_memberDoesNotExist_expect_throwsNotExistedMemberException() {
 			String email = "comen@comen.com";
 
-			given(memberMapper.findByEmail(anyString())).willThrow(MemberNotFoundException.class);
+			given(memberMapper.findByEmail(anyString())).willThrow(NotExistedMemberException.class);
 
-			assertThrows(MemberNotFoundException.class, () -> {
+			assertThrows(NotExistedMemberException.class, () -> {
 				memberService.getByEmail(email);
 			});
 		}


### PR DESCRIPTION
## 내용
Exception handling 시 에러 메시지를 템플릿화 할 수 있는 Response 객체를 추가했습니다.

<br>

**컬럼 정보**
- `status` : Status code
- `error` : Status code와 연관되는 메시지
- `message` : 반환할 에러 메시지

<br>

## 참고
- DuplicatedEmailException 명시적인 상황을 나타내기 위해 커스텀 예외가 추가됐습니다.
- Exception naming 통일감을 위해 기존 예외의 이름을 변경했습니다.
  - MemberNotFoundException -> NotExistedMemberException 
- 변경된 에러 메시지입니다. 
<img width="384" alt="스크린샷 2023-04-05 오후 4 09 57" src="https://user-images.githubusercontent.com/80027033/230006964-cbb82338-55ec-4614-a851-7bb846aa0dfc.png">
