### PR TITLE
로그인 - Refresh token 구현 및 테스트 코드 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.0.0'
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -14,15 +14,55 @@ endif::[]
 === 1. 회원가입
 
 **request_fields**
+
 include::{snippets}/member-join/request-fields.adoc[]
 
 **response_fields**
+
 include::{snippets}/member-join/response-fields.adoc[]
 
 **http_request**
+
 include::{snippets}/member-join/request-body.adoc[]
 
 **http_response**
+
 include::{snippets}/member-join/http-response.adoc[]
 
 ---
+
+=== 2. 로그인
+
+**request_fields**
+
+include::{snippets}/auth-login/request-fields.adoc[]
+
+**response_fields**
+
+include::{snippets}/auth-login/response-fields.adoc[]
+
+**http_request**
+
+include::{snippets}/auth-login/request-body.adoc[]
+
+**http_response**
+
+include::{snippets}/auth-login/http-response.adoc[]
+
+==== 액세스 토큰 재발급
+
+**request_fields**
+
+include::{snippets}/auth-reissue/request-fields.adoc[]
+
+**response_fields**
+
+include::{snippets}/auth-reissue/response-fields.adoc[]
+
+**http_request**
+
+include::{snippets}/auth-reissue/request-body.adoc[]
+
+**http_response**
+
+include::{snippets}/auth-reissue/http-response.adoc[]

--- a/src/main/java/com/flab/comen/global/config/SecurityConfig.java
+++ b/src/main/java/com/flab/comen/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
 			.and()
 			.authorizeHttpRequests(authorize ->
 				authorize
-					.requestMatchers("/api/v1/members/join", "/api/v1/members/login").permitAll()
+					.requestMatchers("/api/v1/members/join", "/api/v1/auth/**").permitAll()
 					.requestMatchers("/api/v1/mentees/**").hasAuthority(String.valueOf(Role.MENTEE))
 					.requestMatchers("/api/v1/coaches/**").hasAuthority(String.valueOf(Role.COACH))
 					.anyRequest().authenticated())

--- a/src/main/java/com/flab/comen/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/flab/comen/global/exception/ApiExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import com.flab.comen.member.exception.DuplicatedEmailException;
 import com.flab.comen.member.exception.NotActivatedMemberException;
 import com.flab.comen.member.exception.NotExistedMemberException;
+import com.flab.comen.member.exception.NotExistedTokenException;
 import com.flab.comen.member.exception.NotMatchedInformationException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -56,5 +57,11 @@ public class ApiExceptionHandler {
 	private ResponseEntity<ErrorResponse> handleNotActivatedMemberException(NotActivatedMemberException exception) {
 		log.error("NotActivatedMemberException : ", exception);
 		return ErrorResponse.toResponseEntity(NOT_ACTIVATED_MEMBER);
+	}
+
+	@ExceptionHandler(NotExistedTokenException.class)
+	private ResponseEntity<ErrorResponse> handleInvalidTokenException(NotExistedTokenException exception) {
+		log.error("InvalidTokenException : ", exception);
+		return ErrorResponse.toResponseEntity(NOT_EXISTED_TOKEN);
 	}
 }

--- a/src/main/java/com/flab/comen/global/exception/ErrorMessage.java
+++ b/src/main/java/com/flab/comen/global/exception/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
 	NOT_MATCHED_LOGIN_INFORMATION(HttpStatus.CONFLICT, "아이디나 패스워드가 일치하지 않습니다."),
 
 	// jwt
+	NOT_EXISTED_TOKEN(HttpStatus.NOT_FOUND, "등록된 토큰 정보가 없습니다."),
 	UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "인증이 필요한 토큰입니다."),
 	FORBIDDEN_TOKEN(HttpStatus.FORBIDDEN, "권한이 필요한 토큰입니다.");
 

--- a/src/main/java/com/flab/comen/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/flab/comen/global/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.flab.comen.global.jwt;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -61,6 +62,10 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
+	public String generateRefreshToken() {
+		return UUID.randomUUID().toString();
+	}
+
 	public Authentication getAuthentication(String token) {
 		UserDetails userDetails = principalDetailsService.loadUserByUsername(getMemberEmail(token));
 		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
@@ -71,6 +76,13 @@ public class JwtTokenProvider {
 			.setSigningKey(secretKey)
 			.parseClaimsJws(token)
 			.getBody().getSubject();
+	}
+
+	public String getRole(String token) {
+		return (String)Jwts.parser()
+			.setSigningKey(secretKey)
+			.parseClaimsJws(token)
+			.getBody().get(ROLE);
 	}
 
 	public Optional<String> resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/flab/comen/global/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/flab/comen/global/jwt/domain/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.flab.comen.global.jwt.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshToken {
+	private String email;
+	private String refreshToken;
+	private LocalDateTime expiredTime;
+
+	public static RefreshToken of(String email, String refreshToken, LocalDateTime expiredTime) {
+		RefreshToken token = new RefreshToken();
+		token.email = email;
+		token.refreshToken = refreshToken;
+		token.expiredTime = expiredTime;
+		return token;
+	}
+}

--- a/src/main/java/com/flab/comen/global/jwt/repository/TokenCache.java
+++ b/src/main/java/com/flab/comen/global/jwt/repository/TokenCache.java
@@ -1,0 +1,37 @@
+package com.flab.comen.global.jwt.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.flab.comen.global.jwt.domain.RefreshToken;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Component
+public class TokenCache {
+
+	private final Cache<String, RefreshToken> cache;
+
+	private static final int expirationDate = 14;
+
+	public TokenCache() {
+		this.cache = Caffeine.newBuilder()
+			.expireAfterWrite(expirationDate, TimeUnit.DAYS)
+			.build();
+	}
+
+	public void saveToken(String email, String refreshToken) {
+		cache.put(email, RefreshToken.of(email, refreshToken, LocalDateTime.now().plusDays(expirationDate)));
+	}
+
+	public void deleteToken(String email) {
+		cache.invalidate(email);
+	}
+
+	public Optional<RefreshToken> hasToken(String email) {
+		return Optional.ofNullable(cache.getIfPresent(email));
+	}
+}

--- a/src/main/java/com/flab/comen/member/controller/AuthenticationController.java
+++ b/src/main/java/com/flab/comen/member/controller/AuthenticationController.java
@@ -1,0 +1,35 @@
+package com.flab.comen.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.flab.comen.member.dto.request.LoginRequest;
+import com.flab.comen.member.dto.request.ReIssueRequest;
+import com.flab.comen.member.dto.response.TokenResponse;
+import com.flab.comen.member.service.AuthenticationService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthenticationController {
+
+	private final AuthenticationService authenticationService;
+
+	public AuthenticationController(AuthenticationService authenticationService) {
+		this.authenticationService = authenticationService;
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest dto) {
+		return ResponseEntity.ok(authenticationService.login(dto));
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<TokenResponse> reissueToken(@RequestBody @Valid ReIssueRequest dto) {
+		return ResponseEntity.ok(authenticationService.reissueToken(dto));
+	}
+}

--- a/src/main/java/com/flab/comen/member/controller/MemberController.java
+++ b/src/main/java/com/flab/comen/member/controller/MemberController.java
@@ -7,10 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.comen.member.dto.request.JoinRequest;
-import com.flab.comen.member.dto.request.LoginRequest;
 import com.flab.comen.member.dto.response.JoinResponse;
-import com.flab.comen.member.dto.response.TokenResponse;
-import com.flab.comen.member.service.AuthenticationService;
 import com.flab.comen.member.service.MemberService;
 
 import jakarta.validation.Valid;
@@ -21,20 +18,12 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	private final AuthenticationService authenticationService;
-
-	public MemberController(MemberService memberService, AuthenticationService authenticationService) {
+	public MemberController(MemberService memberService) {
 		this.memberService = memberService;
-		this.authenticationService = authenticationService;
 	}
 
 	@PostMapping("/join")
 	public ResponseEntity<JoinResponse> join(@RequestBody @Valid JoinRequest dto) {
 		return ResponseEntity.ok(memberService.join(dto));
-	}
-
-	@PostMapping("/login")
-	public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest dto) {
-		return ResponseEntity.ok(authenticationService.login(dto));
 	}
 }

--- a/src/main/java/com/flab/comen/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/flab/comen/member/dto/request/LoginRequest.java
@@ -2,15 +2,13 @@ package com.flab.comen.member.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
 
-@Getter
-public class LoginRequest {
-
+public record LoginRequest(
 	@Email
 	@NotBlank(message = "이메일 주소를 입력해 주세요.")
-	private String email;
+	String email,
 
 	@NotBlank(message = "비밀번호를 입력해 주세요.")
-	private String password;
+	String password
+) {
 }

--- a/src/main/java/com/flab/comen/member/dto/request/ReIssueRequest.java
+++ b/src/main/java/com/flab/comen/member/dto/request/ReIssueRequest.java
@@ -1,0 +1,11 @@
+package com.flab.comen.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReIssueRequest(
+	@NotBlank(message = "액세스 토큰 정보가 필요합니다.")
+	String accessToken,
+	@NotBlank(message = "리프레시 토큰 정보가 필요합니다.")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/flab/comen/member/dto/response/TokenResponse.java
+++ b/src/main/java/com/flab/comen/member/dto/response/TokenResponse.java
@@ -1,13 +1,7 @@
 package com.flab.comen.member.dto.response;
 
-import lombok.Getter;
-
-@Getter
-public class TokenResponse {
-
-	private String accessToken;
-
-	public TokenResponse(String accessToken) {
-		this.accessToken = accessToken;
-	}
+public record TokenResponse(
+	String accessToken,
+	String refreshToken
+) {
 }

--- a/src/main/java/com/flab/comen/member/exception/NotExistedTokenException.java
+++ b/src/main/java/com/flab/comen/member/exception/NotExistedTokenException.java
@@ -1,0 +1,9 @@
+package com.flab.comen.member.exception;
+
+import com.flab.comen.global.exception.ErrorMessage;
+
+public class NotExistedTokenException extends RuntimeException {
+	public NotExistedTokenException(ErrorMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/com/flab/comen/member/service/AuthenticationService.java
+++ b/src/main/java/com/flab/comen/member/service/AuthenticationService.java
@@ -5,11 +5,15 @@ import org.springframework.stereotype.Service;
 
 import com.flab.comen.global.exception.ErrorMessage;
 import com.flab.comen.global.jwt.JwtTokenProvider;
+import com.flab.comen.global.jwt.repository.TokenCache;
 import com.flab.comen.member.domain.ActiveType;
 import com.flab.comen.member.domain.Member;
+import com.flab.comen.member.domain.Role;
 import com.flab.comen.member.dto.request.LoginRequest;
+import com.flab.comen.member.dto.request.ReIssueRequest;
 import com.flab.comen.member.dto.response.TokenResponse;
 import com.flab.comen.member.exception.NotActivatedMemberException;
+import com.flab.comen.member.exception.NotExistedTokenException;
 import com.flab.comen.member.exception.NotMatchedInformationException;
 import com.flab.comen.member.mapper.MemberMapper;
 
@@ -19,30 +23,56 @@ public class AuthenticationService {
 	private final MemberMapper memberMapper;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final TokenCache tokenCache;
 
 	public AuthenticationService(MemberMapper memberMapper, PasswordEncoder passwordEncoder,
-		JwtTokenProvider jwtTokenProvider) {
+		JwtTokenProvider jwtTokenProvider, TokenCache tokenCache) {
 		this.memberMapper = memberMapper;
 		this.passwordEncoder = passwordEncoder;
 		this.jwtTokenProvider = jwtTokenProvider;
+		this.tokenCache = tokenCache;
 	}
 
 	public TokenResponse login(LoginRequest loginRequest) {
-		Member member = memberMapper.findByEmail(loginRequest.getEmail()).orElseThrow(() ->
-			new NotMatchedInformationException(ErrorMessage.NOT_MATCHED_LOGIN_INFORMATION));
+		Member member = memberMapper.findByEmail(loginRequest.email())
+			.filter(m -> isMatchedPassword(loginRequest.password(), m.getPassword()))
+			.orElseThrow(() -> new NotMatchedInformationException(ErrorMessage.NOT_MATCHED_LOGIN_INFORMATION));
 
-		if (!isMatchedPassword(loginRequest.getPassword(), member.getPassword())) {
-			throw new NotMatchedInformationException(ErrorMessage.NOT_MATCHED_LOGIN_INFORMATION);
-		}
-
-		if (!ActiveType.ACTIVE.equals(member.getActiveType())) {
+		if (!isActiveMember(member)) {
 			throw new NotActivatedMemberException(ErrorMessage.NOT_ACTIVATED_MEMBER);
 		}
 
-		return new TokenResponse(jwtTokenProvider.generateAccessToken(member.getEmail(), member.getRole()));
+		String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getRole());
+		String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+		tokenCache.saveToken(member.getEmail(), refreshToken);
+
+		return new TokenResponse(accessToken, refreshToken);
 	}
 
 	public boolean isMatchedPassword(String password, String existedPassword) {
 		return passwordEncoder.matches(password, existedPassword);
+	}
+
+	public boolean isActiveMember(Member member) {
+		return ActiveType.ACTIVE.equals(member.getActiveType());
+	}
+
+	public TokenResponse reissueToken(ReIssueRequest request) {
+		String accessToken = request.accessToken();
+		String refreshToken = request.refreshToken();
+
+		String memberEmail = jwtTokenProvider.getMemberEmail(accessToken);
+		String role = jwtTokenProvider.getRole(accessToken);
+
+		validateRefreshToken(memberEmail);
+
+		accessToken = jwtTokenProvider.generateAccessToken(memberEmail, Role.valueOf(role));
+
+		return new TokenResponse(accessToken, refreshToken);
+	}
+
+	public void validateRefreshToken(String email) {
+		tokenCache.hasToken(email).orElseThrow(() -> new NotExistedTokenException(ErrorMessage.NOT_EXISTED_TOKEN));
 	}
 }

--- a/src/main/java/com/flab/comen/member/service/MemberService.java
+++ b/src/main/java/com/flab/comen/member/service/MemberService.java
@@ -4,6 +4,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.flab.comen.global.exception.ErrorMessage;
+import com.flab.comen.member.domain.ActiveType;
 import com.flab.comen.member.domain.Member;
 import com.flab.comen.member.dto.request.JoinRequest;
 import com.flab.comen.member.dto.response.JoinResponse;
@@ -47,5 +48,9 @@ public class MemberService {
 		return memberMapper.findByEmail(email).orElseThrow(() -> {
 			throw new NotExistedMemberException(ErrorMessage.NOT_EXISTED_MEMBER);
 		});
+	}
+
+	public boolean isActiveMember(Member member) {
+		return ActiveType.ACTIVE.equals(member.getActiveType());
 	}
 }

--- a/src/test/java/com/flab/comen/member/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/flab/comen/member/controller/AuthenticationControllerTest.java
@@ -1,0 +1,167 @@
+package com.flab.comen.member.controller;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.comen.member.dto.request.LoginRequest;
+import com.flab.comen.member.dto.request.ReIssueRequest;
+import com.flab.comen.member.dto.response.TokenResponse;
+import com.flab.comen.member.service.AuthenticationService;
+import com.flab.comen.member.util.ControllerTest;
+
+@WebMvcTest(AuthenticationController.class)
+public class AuthenticationControllerTest extends ControllerTest {
+
+	@MockBean
+	private AuthenticationService authenticationService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Nested
+	@DisplayName("로그인")
+	class LoginTest {
+		@Test
+		@DisplayName("조건에 맞는 모든 필드를 입력받으면 로그인이 성공한다.")
+		void when_allFieldsAreEntered_expects_loginToSuccess() throws Exception {
+			LoginRequest loginRequest = new LoginRequest("comen@comen.com", "1234!Comen");
+			TokenResponse tokenResponse = new TokenResponse("accessToken", "refreshToken");
+
+			BDDMockito.given(authenticationService.login(BDDMockito.any())).willReturn(tokenResponse);
+
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(loginRequest))
+				)
+				.andDo(MockMvcResultHandlers.print())
+				.andDo(document("auth-login",
+					preprocessRequest(modifyUris()
+						.port(9090), prettyPrint()),
+					requestFields(
+						fieldWithPath("email").type(JsonFieldType.STRING).description("등록된 이메일 주소"),
+						fieldWithPath("password").type(JsonFieldType.STRING).description("등록된 비밀번호")
+					),
+					responseFields(
+						fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
+						fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰")
+					)));
+
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("email 필드가 null, empty, blank 상태라면 로그인이 실패한다.")
+		void when_emailFieldIsNullAndEmptyAndBlank_expect_loginToFail(String email) throws Exception {
+			LoginRequest loginRequest = new LoginRequest(email, "1234!Comen");
+
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(loginRequest))
+				)
+				.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("password 필드가 null, empty, blank 상태라면 로그인이 실패한다.")
+		void when_passwordFieldIsNullAndEmptyAndBlank_expect_loginToFail(String password) throws Exception {
+			LoginRequest loginRequest = new LoginRequest("comen@comen.com", password);
+
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(loginRequest))
+				)
+				.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("액세스 토큰 재발급")
+	class ReissueTest {
+		@Test
+		@DisplayName("조건에 맞는 모든 필드를 입력받으면 재발급이 성공한다.")
+		void when_allFieldsAreEntered_expects_reissueToSuccess() throws Exception {
+			ReIssueRequest reIssueRequest = new ReIssueRequest("accessToken", "refreshToken");
+			TokenResponse tokenResponse = new TokenResponse("newAccessToken", "newRefreshToken");
+
+			BDDMockito.given(authenticationService.reissueToken(BDDMockito.any())).willReturn(tokenResponse);
+
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/reissue")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(reIssueRequest))
+				)
+				.andDo(MockMvcResultHandlers.print())
+				.andDo(document("auth-reissue",
+					preprocessRequest(modifyUris()
+						.port(9090), prettyPrint()),
+					requestFields(
+						fieldWithPath("accessToken").type(JsonFieldType.STRING).description("기존에 발급받은 액세스 토큰"),
+						fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("기존에 발급받은 리프레시 토큰")
+					),
+					responseFields(
+						fieldWithPath("accessToken").type(JsonFieldType.STRING).description("재발급된 액세스 토큰"),
+						fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("기존에 발급받은 리프레시 토큰")
+					)));
+
+			response.andExpect(MockMvcResultMatchers.status().isOk());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("accessToken 필드가 null, empty, blank 상태라면 로그인이 실패한다.")
+		void when_accessTokenFieldIsNullAndEmptyAndBlank_expect_loginToFail(String accessToken) throws Exception {
+			ReIssueRequest reIssueRequest = new ReIssueRequest(accessToken, "refreshToken");
+
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/reissue")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(reIssueRequest))
+				)
+				.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+
+		@ParameterizedTest
+		@NullAndEmptySource
+		@ValueSource(strings = {" "})
+		@DisplayName("refreshToken 필드가 null, empty, blank 상태라면 로그인이 실패한다.")
+		void when_refreshTokenFieldIsNullAndEmptyAndBlank_expect_loginToFail(String refreshToken) throws Exception {
+			ReIssueRequest reIssueRequest = new ReIssueRequest("accessToken", refreshToken);
+
+			ResultActions response = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/reissue")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(reIssueRequest))
+				)
+				.andDo(MockMvcResultHandlers.print());
+
+			response.andExpect(MockMvcResultMatchers.status().isBadRequest());
+		}
+	}
+}

--- a/src/test/java/com/flab/comen/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/flab/comen/member/controller/MemberControllerTest.java
@@ -9,52 +9,33 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.comen.member.domain.ActiveType;
 import com.flab.comen.member.domain.Role;
 import com.flab.comen.member.dto.request.JoinRequest;
 import com.flab.comen.member.dto.response.JoinResponse;
-import com.flab.comen.member.service.AuthenticationService;
 import com.flab.comen.member.service.MemberService;
+import com.flab.comen.member.util.ControllerTest;
 
 @WebMvcTest(MemberController.class)
-@AutoConfigureMockMvc(addFilters = false)
-@AutoConfigureMybatis
-@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
-class MemberControllerTest {
-
-	@Autowired
-	private MockMvc mockMvc;
+class MemberControllerTest extends ControllerTest {
 
 	@MockBean
 	private MemberService memberService;
-
-	@MockBean
-	private AuthenticationService authenticationService;
 
 	@Autowired
 	private ObjectMapper objectMapper;
@@ -63,13 +44,6 @@ class MemberControllerTest {
 	public static final String PASSWORD = "1234!Comen";
 	public static final String NAME = "김코멘";
 	public static final Role ROLE = MENTEE;
-
-	@BeforeEach
-	public void setUp(WebApplicationContext webApplicationContext,
-		RestDocumentationContextProvider restDocumentation) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-			.apply(documentationConfiguration(restDocumentation)).build();
-	}
 
 	@Nested
 	@DisplayName("회원가입")

--- a/src/test/java/com/flab/comen/member/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/flab/comen/member/service/AuthenticationServiceTest.java
@@ -4,17 +4,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.flab.comen.global.jwt.JwtTokenProvider;
 import com.flab.comen.global.jwt.repository.TokenCache;
-import com.flab.comen.member.domain.ActiveType;
-import com.flab.comen.member.domain.Member;
-import com.flab.comen.member.domain.Role;
 import com.flab.comen.member.exception.NotExistedTokenException;
 import com.flab.comen.member.mapper.MemberMapper;
 
@@ -59,18 +54,6 @@ public class AuthenticationServiceTest {
 
 			Assertions.assertFalse(
 				authenticationService.isMatchedPassword(otherPassword, encodedPassword)
-			);
-		}
-
-		@ParameterizedTest
-		@ValueSource(strings = {"INACTIVE", "DELETE"})
-		@DisplayName("회원이 활성화 상태가 아니면 로그인이 실패한다.")
-		void when_memberINotActive_expects_loginToFail(String activeType) {
-			Member member = Member.of("comen@comen.com", "1234Q!wert", "김코멘", Role.MENTEE,
-				ActiveType.valueOf(activeType));
-
-			Assertions.assertFalse(
-				authenticationService.isActiveMember(member)
 			);
 		}
 	}

--- a/src/test/java/com/flab/comen/member/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/flab/comen/member/service/AuthenticationServiceTest.java
@@ -4,11 +4,18 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.flab.comen.global.jwt.JwtTokenProvider;
+import com.flab.comen.global.jwt.repository.TokenCache;
+import com.flab.comen.member.domain.ActiveType;
+import com.flab.comen.member.domain.Member;
+import com.flab.comen.member.domain.Role;
+import com.flab.comen.member.exception.NotExistedTokenException;
 import com.flab.comen.member.mapper.MemberMapper;
 
 @SpringBootTest
@@ -24,6 +31,9 @@ public class AuthenticationServiceTest {
 	JwtTokenProvider jwtTokenProvider;
 
 	@Autowired
+	TokenCache tokenCache;
+
+	@Autowired
 	AuthenticationService authenticationService;
 
 	@Nested
@@ -31,7 +41,7 @@ public class AuthenticationServiceTest {
 	class LoginTest {
 		@Test
 		@DisplayName("패스워드가 일치하면 로그인이 성공한다.")
-		void whenPasswordMatched_expects_loginToSuccess() {
+		void when_passwordMatched_expects_loginToSuccess() {
 			String password = "1234Q!wert";
 			String encodedPassword = passwordEncoder.encode(password);
 
@@ -42,7 +52,7 @@ public class AuthenticationServiceTest {
 
 		@Test
 		@DisplayName("패스워드가 일치하지 않으면 로그인이 실패한다.")
-		void whenPasswordNotMatched_expects_loginToFail() {
+		void when_passwordNotMatched_expects_loginToFail() {
 			String password = "1234Q!wert";
 			String otherPassword = "password";
 			String encodedPassword = passwordEncoder.encode(password);
@@ -51,6 +61,34 @@ public class AuthenticationServiceTest {
 				authenticationService.isMatchedPassword(otherPassword, encodedPassword)
 			);
 		}
+
+		@ParameterizedTest
+		@ValueSource(strings = {"INACTIVE", "DELETE"})
+		@DisplayName("회원이 활성화 상태가 아니면 로그인이 실패한다.")
+		void when_memberINotActive_expects_loginToFail(String activeType) {
+			Member member = Member.of("comen@comen.com", "1234Q!wert", "김코멘", Role.MENTEE,
+				ActiveType.valueOf(activeType));
+
+			Assertions.assertFalse(
+				authenticationService.isActiveMember(member)
+			);
+		}
 	}
 
+	@Nested
+	@DisplayName("액세스 토큰 재발급")
+	class ReissueTest {
+		@Test
+		@DisplayName("등록된 리프레시 토큰이 없다면 NotExistedTokenException이 발생한다.")
+		void when_tokenIsNotExist_expect_throwsNotExistedTokenException() {
+			String email = "comen@comen.com";
+			tokenCache.saveToken(email, "refreshToken");
+
+			tokenCache.deleteToken(email);
+
+			Assertions.assertThrows(NotExistedTokenException.class, () -> {
+				authenticationService.validateRefreshToken(email);
+			});
+		}
+	}
 }

--- a/src/test/java/com/flab/comen/member/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/comen/member/service/MemberServiceTest.java
@@ -7,15 +7,20 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.flab.comen.member.domain.ActiveType;
 import com.flab.comen.member.domain.Member;
+import com.flab.comen.member.domain.Role;
 import com.flab.comen.member.dto.request.JoinRequest;
 import com.flab.comen.member.exception.DuplicatedEmailException;
 import com.flab.comen.member.exception.NotExistedMemberException;
@@ -57,5 +62,17 @@ class MemberServiceTest {
 				memberService.getByEmail(email);
 			});
 		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"INACTIVE", "DELETE"})
+	@DisplayName("회원이 활성화 상태가 아니면 false를 반환한다.")
+	void when_memberINotActive_expects_returnFalse(String activeType) {
+		Member member = Member.of("comen@comen.com", "1234Q!wert", "김코멘", Role.MENTEE,
+			ActiveType.valueOf(activeType));
+
+		Assertions.assertFalse(
+			memberService.isActiveMember(member)
+		);
 	}
 }

--- a/src/test/java/com/flab/comen/member/util/ControllerTest.java
+++ b/src/test/java/com/flab/comen/member/util/ControllerTest.java
@@ -1,0 +1,29 @@
+package com.flab.comen.member.util;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mybatis.spring.boot.test.autoconfigure.AutoConfigureMybatis;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMybatis
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+public class ControllerTest {
+
+	protected MockMvc mockMvc;
+
+	@BeforeEach
+	public void setUp(WebApplicationContext webApplicationContext,
+		RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+			.apply(documentationConfiguration(restDocumentation)).build();
+	}
+}


### PR DESCRIPTION
## 내용
로컬 캐시를 활용하여 리프레시 토큰 기능을 구현했습니다.
- 만료 기한이 지나면 자동으로 리프레시 토큰 제거
- 리프레시 토큰 존재 여부 검증 후 액세스 토큰 재발급
